### PR TITLE
Fix build error on newer MacOS due to implicit declaration of panic

### DIFF
--- a/nsd/nsd.h
+++ b/nsd/nsd.h
@@ -1092,4 +1092,8 @@ extern Tcl_Encoding NsGetOutputEncoding(Conn *connPtr);
 
 extern int NsConnRunProxyRequest(Ns_Conn *conn);
 
+#ifdef __APPLE__
+extern void panic(char * format, ...);
+#endif
+
 #endif

--- a/nsd/tclloop.c
+++ b/nsd/tclloop.c
@@ -36,6 +36,10 @@
 
 static const char *RCSID = "@(#) $Header: /Users/dossy/Desktop/cvs/aolserver/nsd/tclloop.c,v 1.4 2009/12/24 19:50:08 dvrsn Exp $, compiled: " __DATE__ " " __TIME__;
 
+#ifdef __APPLE__
+#include <ctype.h>
+#endif
+
 #include "nsd.h"
 
 /*


### PR DESCRIPTION
The PR fixes build error on newer MacOS:
```
tclloop.c:422:3: error: implicit declaration of function 'panic' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
```
Fix borrowed from: https://github.com/macports/macports-ports/commit/80d3dcac293a2a80c1a503c9a8f6e231ffd98001