### PR TITLE
configure: avoid implicitly declaring exit()

### DIFF
--- a/configure
+++ b/configure
@@ -2838,6 +2838,7 @@ _ACEOF
 cat confdefs.h >>conftest.$ac_ext
 cat >>conftest.$ac_ext <<_ACEOF
 /* end confdefs.h.  */
+#include <stdlib.h>
 #include <ctype.h>
 #if ((' ' & 0x0FF) == 0x020)
 # define ISLOWER(c) ('a' <= (c) && (c) <= 'z')


### PR DESCRIPTION
This fixes an issue where `checking for ANSI C header files…` outputs `no` on Xcode clang 12 and later, because its check is missing `#include <stdlib.h>`, causing `exit()` to be implicitly declared, which Xcode clang 12 and later consider an error by default:

```
configure:2866: clang -o conftest   conftest.c  >&5
configure:2860:7: error: implicitly declaring library function 'exit' with type 'void (int) __attribute__((noreturn))' [-Werror,-Wimplicit-function-declaration]
      exit(2);
      ^
configure:2860:7: note: include the header <stdlib.h> or explicitly provide a declaration for 'exit'
```