### PR TITLE
Migrate to Tcl_Panic()

### DIFF
--- a/nsd/tclloop.c
+++ b/nsd/tclloop.c
@@ -414,12 +414,12 @@ NsTclForeachObjCmd(arg, interp, objc, objv)
 	    result = Tcl_ListObjGetElements(interp, argObjv[1+i*2],
 		    &varcList[i], &varvList[i]);
 	    if (result != TCL_OK) {
-		panic("Tcl_ForeachObjCmd: could not reconvert variable list %d to a list object\n", i);
+		Tcl_Panic("Tcl_ForeachObjCmd: could not reconvert variable list %d to a list object\n", i);
 	    }
 	    result = Tcl_ListObjGetElements(interp, argObjv[2+i*2],
 		    &argcList[i], &argvList[i]);
 	    if (result != TCL_OK) {
-		panic("Tcl_ForeachObjCmd: could not reconvert value list %d to a list object\n", i);
+		Tcl_Panic("Tcl_ForeachObjCmd: could not reconvert value list %d to a list object\n", i);
 	    }
 	    
 	    for (v = 0;  v < varcList[i];  v++) {

--- a/nsd/tclxkeylist.c
+++ b/nsd/tclxkeylist.c
@@ -45,7 +45,7 @@ static const char *RCSID = "@(#) $Header: /Users/dossy/Desktop/cvs/aolserver/nsd
  */
 #ifdef TCLX_DEBUG
 #   define TclX_Assert(expr) ((expr) ? (void)0 : \
-                              panic("TclX assertion failure: %s:%d \"%s\"\n",\
+                              Tcl_Panic("TclX assertion failure: %s:%d \"%s\"\n",\
                                     __FILE__, __LINE__, "expr"))
 #else
 #   define TclX_Assert(expr)


### PR DESCRIPTION
Replaces usage of Tcl `panic()` function which is deprecated and unavailable on macOS due to conflict with system `panic()`.

Alternative to #7